### PR TITLE
Added method to wrap entire services with $async

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ $async is an async/await implementation based on generators for use with angular
 `npm install ng-async`
 
 # Usage
+
+## As service
 ```javascript
 import ngAsync from 'ng-async';
 
@@ -20,6 +22,23 @@ angular.module('my-module', [ngAsync.name])
 		});
 	});
 ```
+
+## To wrap a service/controller
+
+```javascript
+import ngAsync, { $async } from 'ng-async';
+
+angular.module('my-module', [ngAsync.name])
+	.controller('my-controller', $async(function*($http) {
+		'ngInject';
+		const { data : users } = yield $http.get('/users');
+		$scope.users = users;
+	}));
+```
+
+Note: To wrap a service/controller it *must* be explicitly annotated. The example uses [ng-annotate](https://github.com/olov/ng-annotate) to do it for us.
+
+Note: keep in mind that an `$async` function returns a promise, not a value. This is especially important with factories, since their return value will be used for injection.
 
 # Prerequisites
 

--- a/src/index.js
+++ b/src/index.js
@@ -36,3 +36,39 @@ export default angular.module('mm.$async', [])
 			}
 		}
 	}]);
+
+/**
+ * Wrapper to make an entire service/controller async.
+ *
+ * The async service MUST be explicitely annotated for this to work.
+ *
+ * Example usage:
+ *
+ * angular.controller($async(['$http', function*($http) {
+ *   const data =yield $http.get('somedata');
+ * })]);
+ *
+ * It also works well together with ng-annotate:
+ *
+ * angular.controller($async(function*($http) {
+ *   'ngInject';
+ *   const data =yield $http.get('somedata');
+ * }));
+ */
+export const $async = function(annotatedService) {
+	if (!Array.isArray(annotatedService)) {
+		throw new Error('$async services must use explicit annotations for its dependencies');
+	}
+
+	//We're going to wrap the async service function, so we first need to extract it from the array
+	const serviceFunction = annotatedService.pop();
+
+	//Our wrapper needs $async to work. We pre-prend it to the dependencies such that the wrapper gets
+	//it as the first argument
+	annotatedService.unshift('$async');
+	//The wrapper simply wraps the serviceFunction with $async and then proxies the dependencies to
+	//the async service
+	annotatedService.push(($async, ...deps) => $async(serviceFunction).apply(this, deps));
+
+	return annotatedService;
+}


### PR DESCRIPTION
The current implementation only gives you the fanciness of async within
services, but sometimes it's also desirable to make a service itself
async. The newly named `$async` export will allow to do just that.

This method is especially useful for controllers that have a lot of asynchronous initialization logic. When used properly these controllers will now be initialized when the bottom of the controller is used.

@Magnetme/monolith - RFR! If this is merged I'll publish it and PR it into the Magnet.me repo