### PR TITLE
Added experimental support to enable native async/await in angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,35 @@ $async is an async/await implementation based on generators for use with angular
 
 # Usage
 
+## Experimental: native async-await
+1. Install babel's `transform-async-to-module-method` plugin
+2. Configure it as follows:
+```json
+"plugins" : [
+	["transform-async-to-module-method", {
+		"module": "ng-async",
+		"method": "wrap"
+	}]
+]
+```
+3. Use the native async-await syntax:
+
+```javascript
+angular.module('my-module', [])
+	.controller('my-controller', () => {
+		async function init() {
+			const { data : users } = await $http.get('/users');
+			$scope.users = users;
+		}
+	});
+```
+
+Note: This is still experimental, may contain bugs
+
+Note2: Using this plugin will result in `angular` being imported in every file
+uses async/await. Make sure to disable this plugin for scripts where you don't
+want this.
+
 ## As service
 ```javascript
 import ngAsync from 'ng-async';

--- a/src/index.js
+++ b/src/index.js
@@ -72,3 +72,11 @@ export const $async = function(annotatedService) {
 
 	return annotatedService;
 }
+
+/**
+ * Function to wrap any generator function in `$async`, regardless if it's used
+ * in an Angular application or not. The main use case of this function is to
+ * make it possible to use it with babel's transform-async-to-module-method
+ * plugin.
+ */
+export const wrap = angular.injector(['ng', 'mm.$async']).get('$async');


### PR DESCRIPTION
With the help of babel's `transform-async-to-module-method` plugin we
can automatically transform async/await functions into wrapped generator
functions. `$async` already worked with wrapped generator functions, so
with a little bit of magic we can let babel do the transformation for
us.

For more info see the updated readme